### PR TITLE
updates SeePopNotServed tool for GP service

### DIFF
--- a/WPDx_Toolset.pyt
+++ b/WPDx_Toolset.pyt
@@ -17,8 +17,10 @@ import json
 import sys
 dacc = arcpy.da
 import time
+import os
 
-loc = r"C:\Users\esri\Desktop\Archive"
+# loc = r"C:\Users\esri\Desktop\Archive"
+loc = os.path.dirname(os.path.abspath(__file__))  # set wd to the folder that contains this script
 fc_adm_zones = "{}\\Data\\ToolData.gdb\\Admin".format(loc)
 fc_area_urban = "{}\\Data\\ToolData.gdb\\Urban".format(loc)
 lyr_new_locations = "{}\\Data\\NewLocations.lyr".format(loc)
@@ -63,6 +65,9 @@ def get_all_image_sources():
 
 def setEnvironment(zone):
     """Limits the processing extent to the given administrative zone"""
+
+    # arcpy overwrite output
+    arcpy.env.overwriteOutput = True
 
     mask = arcpy.FeatureClassToFeatureClass_conversion(
             fc_adm_zones, arcpy.env.scratchGDB, "mask", "{0}='{1}'".format(
@@ -746,8 +751,8 @@ class SeePopNotServed(object):
 
         pop_not_served = getPopNotServed(pnts_buff, pop_grid, fc_area_urban)
         masked = arcpy.sa.ExtractByMask(pop_not_served, mask)
-        # output = arcpy.CopyRaster_management(masked, out_path)
-        parameters[3] = masked # arcpy.MakeRasterLayer_management(masked, "out_raster")
+        output = arcpy.CopyRaster_management(masked, out_path)
+        parameters[3] = output  # arcpy.MakeRasterLayer_management(masked, "out_raster")
 
 
     def getParameterInfo(self):

--- a/WPDx_Toolset.pyt
+++ b/WPDx_Toolset.pyt
@@ -729,7 +729,7 @@ class SeePopNotServed(object):
         zone = parameters[0].valueAsText
         buff_dist = parameters[1].valueAsText
         #pop_grid = parameters[2].value
-        out_path = parameters[3].value
+        out_path = parameters[2].value
         pop_grid = get_all_image_sources().keys()[0]
         Toolbox.dict_population_sources = get_all_image_sources()
 
@@ -752,7 +752,7 @@ class SeePopNotServed(object):
         pop_not_served = getPopNotServed(pnts_buff, pop_grid, fc_area_urban)
         masked = arcpy.sa.ExtractByMask(pop_not_served, mask)
         output = arcpy.CopyRaster_management(masked, out_path)
-        parameters[3] = output  # arcpy.MakeRasterLayer_management(masked, "out_raster")
+        parameters[2] = output  # arcpy.MakeRasterLayer_management(masked, "out_raster")
 
 
     def getParameterInfo(self):
@@ -771,12 +771,12 @@ class SeePopNotServed(object):
             parameterType='Required',
             direction='Input')
 
-        Param2 = arcpy.Parameter(
-            displayName='Population Grid',
-            name='pop_grid',
-            datatype='GPString',
-            parameterType='Required',
-            direction='Input')
+        # Param2 = arcpy.Parameter(
+            # displayName='Population Grid',
+            # name='pop_grid',
+            # datatype='GPString',
+            # parameterType='Required',
+            # direction='Input')
 
         Param3 = arcpy.Parameter(
             displayName='Output Features',
@@ -787,12 +787,13 @@ class SeePopNotServed(object):
 
         Param0.value = 'Arusha'
         Param1.value = '1000'
-        Param2.value = 'Esri'
-        Param2.filter.type = 'ValueList'
-        Param2.filter.list = ['Esri', 'Worldpop']
-        Param3.value = "in_memory\PopNotServed"
+        # Param2.value = 'Esri'
+        # Param2.filter.type = 'ValueList'
+        # Param2.filter.list = ['Esri', 'Worldpop']
+        Param3.value = r"C:\ArcGIS_Files\BlueRaster\WPDx-Toolset-master\PopNotServed_output.tif"
         Param3.symbology = lyr_popnotserved
-        return [Param0, Param1, Param2, Param3]
+        # return [Param0, Param1, Param2, Param3]
+        return [Param0, Param1, Param3]
 
     def isLicensed(self):
         """Set whether tool is licensed to execute."""

--- a/WPDx_Toolset.pyt
+++ b/WPDx_Toolset.pyt
@@ -728,7 +728,6 @@ class SeePopNotServed(object):
         # Get Paramters
         zone = parameters[0].valueAsText
         buff_dist = parameters[1].valueAsText
-        #pop_grid = parameters[2].value
         out_path = parameters[2].value
         pop_grid = get_all_image_sources().keys()[0]
         Toolbox.dict_population_sources = get_all_image_sources()
@@ -771,14 +770,7 @@ class SeePopNotServed(object):
             parameterType='Required',
             direction='Input')
 
-        # Param2 = arcpy.Parameter(
-            # displayName='Population Grid',
-            # name='pop_grid',
-            # datatype='GPString',
-            # parameterType='Required',
-            # direction='Input')
-
-        Param3 = arcpy.Parameter(
+        Param2 = arcpy.Parameter(
             displayName='Output Features',
             name='out_feat',
             datatype='DERasterDataset',
@@ -787,13 +779,10 @@ class SeePopNotServed(object):
 
         Param0.value = 'Arusha'
         Param1.value = '1000'
-        # Param2.value = 'Esri'
-        # Param2.filter.type = 'ValueList'
-        # Param2.filter.list = ['Esri', 'Worldpop']
-        Param3.value = r"C:\ArcGIS_Files\BlueRaster\WPDx-Toolset-master\PopNotServed_output.tif"
-        Param3.symbology = lyr_popnotserved
+        Param2.value = r"C:\ArcGIS_Files\BlueRaster\WPDx-Toolset-master\PopNotServed_output.tif"
+        Param2.symbology = lyr_popnotserved
         # return [Param0, Param1, Param2, Param3]
-        return [Param0, Param1, Param3]
+        return [Param0, Param1, Param2]
 
     def isLicensed(self):
         """Set whether tool is licensed to execute."""


### PR DESCRIPTION
- fixes syntax errors (indentation + missing quote)
- adds time module to the import 
- arcpy.env.overwriteOutput set to true to allow for existing layers to be overwritten by new outputs
- changes loc from a hard path to the parent directory using os abspath
- SeePopNotServed output saved in_memory (swap to hard path in gp service)
